### PR TITLE
Remove unused null context provider

### DIFF
--- a/django_emarsys/context_provider_registry.py
+++ b/django_emarsys/context_provider_registry.py
@@ -7,8 +7,6 @@ from __future__ import unicode_literals
 
 import functools
 
-from django.conf import settings
-
 context_providers = {}
 
 
@@ -45,9 +43,3 @@ def get_context_provider(event_name):
                 "No context provider registered for event '{}' and"
                 " no general context provider registered either."
                 .format(event_name))
-
-
-if settings.EMARSYS_USE_NULL_GENERIC_CONTEXT_PROVIDER:
-    @register_context_provider(None)
-    def null_context_provider(event_name, **kwargs):
-        return {}

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -90,7 +90,6 @@ STATIC_URL = '/static/'
 EMARSYS_ACCOUNT = 'company001'
 EMARSYS_PASSWORD = 'secret'
 EMARSYS_BASE_URI = 'https://suiteN.emarsys.net'
-EMARSYS_USE_NULL_GENERIC_CONTEXT_PROVIDER = True
 
 EMARSYS_EVENTS = {
     "to User, registration complete": {


### PR DESCRIPTION
This is not used from us and also leads to problem if django
was not loaded yet because it depended on the django settings.