### PR TITLE
Explicit log every emarsy error who are not minor

### DIFF
--- a/django_emarsys/event.py
+++ b/django_emarsys/event.py
@@ -246,6 +246,8 @@ def _create_event_instance(event_name, recipient_email, emarsys_event_id,
     try:
         api.trigger_event(emarsys_event_id, recipient_email, context)
     except EmarsysError as e:
+        if e.code not in [2008, 5005]:
+            log.error(e, exc_info=True)
         event.handle_emarsys_error(e)
         return event
 


### PR DESCRIPTION
We produce a lot of emarsys events and we can not track every error so
it happens that somewhere lost in the masses of events.

https://machtfit.atlassian.net/browse/MAC-1835